### PR TITLE
Fix typo: punt volant → punt volat

### DIFF
--- a/index.html
+++ b/index.html
@@ -374,7 +374,7 @@ H· ¡H¿ {H} [H] (H) —H–H- «H» ‹H› ●H○ ◆H◇ ▪H▫ |H@ </span
 
 <em>Turkish dotted i and dotless ı capitalisation</em><br>
 ı i I İ <span class="red"><span class="case">→</span></span> <font style="text-transform: uppercase;"><span id="lang" lang="tr">ı i I İ</span></font><br><br>
-<em>Catalàn punt volant</em><br>
+<em>Catalàn punt volat</em><br>
 cel·la CEL·LA <span class="smallcaps">CEL·LA</span> <span class="red">→</span> <span id="lang" lang="ca">cel·la CEL·LA <span class="smallcaps">CEL·LA</span></span><br><br>
 
 <em>Moldovan and Romanian -cedilla</em><br>


### PR DESCRIPTION
I'm not sure you should be writing "catalàn" as well. "Catalan" in Catalan is _català_, without the last en (that letter only appears in plural and feminine: _catalans_, _catalana_, _catalanes_).